### PR TITLE
Detect `adminer.css` request by DOCUMENT_URI

### DIFF
--- a/4/fastcgi/index.php
+++ b/4/fastcgi/index.php
@@ -29,7 +29,7 @@ namespace docker {
 }
 
 namespace {
-	if (basename($_SERVER['REQUEST_URI']) === 'adminer.css' && is_readable('adminer.css')) {
+	if (basename($_SERVER['DOCUMENT_URI']) === 'adminer.css' && is_readable('adminer.css')) {
 		header('Content-Type: text/css');
 		readfile('adminer.css');
 		exit;

--- a/4/index.php
+++ b/4/index.php
@@ -29,7 +29,7 @@ namespace docker {
 }
 
 namespace {
-	if (basename($_SERVER['REQUEST_URI']) === 'adminer.css' && is_readable('adminer.css')) {
+	if (basename($_SERVER['DOCUMENT_URI']) === 'adminer.css' && is_readable('adminer.css')) {
 		header('Content-Type: text/css');
 		readfile('adminer.css');
 		exit;


### PR DESCRIPTION
Hi,

since this change: https://github.com/vrana/adminer/commit/7f32e2675941bd16f6d2f3c83df1a8c4ed970834 custom css theme file is not served by fastcgi image.
It's because REQUEST_URI contains URL query part (`adminer.css?v=2379363894`) but it should compare just the "document" part (`adminer.css`).

Are you OK with this solution? DOCUMENT_URI has a little different behavior, see https://stackoverflow.com/questions/39254/whats-the-difference-between-document-uri-and-uri-request-in-ssi