### PR TITLE
allow custom designs from a https address

### DIFF
--- a/4/entrypoint.sh
+++ b/4/entrypoint.sh
@@ -2,10 +2,14 @@
 set -e
 
 if [ -n "$ADMINER_DESIGN" ]; then
-	# Only create link on initial start, to ensure that explicit changes to
-	# adminer.css after the container was started once are preserved.
-	if [ ! -e .adminer-init ]; then
-		ln -sf "designs/$ADMINER_DESIGN/adminer.css" .
+    if [ "${ADMINER_DESIGN%:*}" == "https" ]; then
+	  curl -Lo adminer.css $ADMINER_DESIGN
+	else
+		# Only create link on initial start, to ensure that explicit changes to
+		# adminer.css after the container was started once are preserved.
+		if [ ! -e .adminer-init ]; then
+			ln -sf "designs/$ADMINER_DESIGN/adminer.css" .
+		fi
 	fi
 fi
 

--- a/4/fastcgi/entrypoint.sh
+++ b/4/fastcgi/entrypoint.sh
@@ -2,10 +2,14 @@
 set -e
 
 if [ -n "$ADMINER_DESIGN" ]; then
-	# Only create link on initial start, to ensure that explicit changes to
-	# adminer.css after the container was started once are preserved.
-	if [ ! -e .adminer-init ]; then
-		ln -sf "designs/$ADMINER_DESIGN/adminer.css" .
+    if [ "${ADMINER_DESIGN%:*}" == "https" ]; then
+	  curl -Lo adminer.css $ADMINER_DESIGN
+	else
+		# Only create link on initial start, to ensure that explicit changes to
+		# adminer.css after the container was started once are preserved.
+		if [ ! -e .adminer-init ]; then
+			ln -sf "designs/$ADMINER_DESIGN/adminer.css" .
+		fi
 	fi
 fi
 


### PR DESCRIPTION
A couple of custom design mentioned at: https://www.adminer.org/#extras are not included like: hydra or pepa-linha-dark.
With this change one could use any custom design by adding an env variable like:
```
ADMINER_DESIGN=https://raw.githubusercontent.com/pepa-linha/Adminer-Design-Dark/master/adminer.css
```

