### PR TITLE
Hide PHP error

### DIFF
--- a/4/Dockerfile
+++ b/4/Dockerfile
@@ -4,7 +4,8 @@ RUN	echo "upload_max_filesize = 128M" >> /usr/local/etc/php/conf.d/0-upload_larg
 &&	echo "post_max_size = 128M" >> /usr/local/etc/php/conf.d/0-upload_large_dumps.ini \
 &&	echo "memory_limit = 1G" >> /usr/local/etc/php/conf.d/0-upload_large_dumps.ini \
 &&	echo "max_execution_time = 600" >> /usr/local/etc/php/conf.d/0-upload_large_dumps.ini \
-&&	echo "max_input_vars = 5000" >> /usr/local/etc/php/conf.d/0-upload_large_dumps.ini
+&&	echo "max_input_vars = 5000" >> /usr/local/etc/php/conf.d/0-upload_large_dumps.ini \
+&&	echo "display_errors = Off" >> /usr/local/etc/php/php.ini
 
 STOPSIGNAL SIGINT
 

--- a/4/fastcgi/Dockerfile
+++ b/4/fastcgi/Dockerfile
@@ -4,7 +4,8 @@ RUN	echo "upload_max_filesize = 128M" >> /usr/local/etc/php/conf.d/0-upload_larg
 &&	echo "post_max_size = 128M" >> /usr/local/etc/php/conf.d/0-upload_large_dumps.ini \
 &&	echo "memory_limit = 1G" >> /usr/local/etc/php/conf.d/0-upload_large_dumps.ini \
 &&	echo "max_execution_time = 600" >> /usr/local/etc/php/conf.d/0-upload_large_dumps.ini \
-&&	echo "max_input_vars = 5000" >> /usr/local/etc/php/conf.d/0-upload_large_dumps.ini
+&&	echo "max_input_vars = 5000" >> /usr/local/etc/php/conf.d/0-upload_large_dumps.ini \
+&&	echo "display_errors = Off" >> /usr/local/etc/php/php.ini
 
 RUN	addgroup -S adminer \
 &&	adduser -S -G adminer adminer \


### PR DESCRIPTION
Docker tag: `adminer:4.8.1`

When exporting, file content includes PHP error, so can't import that file.
```html
<br />
<b>Warning</b>:  Undefined property: stdClass::$flags in <b>/var/www/html/adminer.php</b> on line <b>200</b><br />
<br />
<b>Warning</b>:  Undefined property: stdClass::$flags in <b>/var/www/html/adminer.php</b> on line <b>200</b><br />
<br />
<b>Warning</b>:  Undefined property: stdClass::$flags in <b>/var/www/html/adminer.php</b> on line <b>200</b><br />
<br />
```