### PR TITLE
For the cases where there are no root rights

### DIFF
--- a/4/Dockerfile
+++ b/4/Dockerfile
@@ -13,6 +13,7 @@ RUN	addgroup -S adminer \
 &&	mkdir -p /var/www/html \
 &&	mkdir -p /var/www/html/plugins-enabled \
 &&	chown -R adminer:adminer /var/www/html
+RUN	chmod 777 /var/www/html/plugins-enabled
 
 WORKDIR /var/www/html
 


### PR DESCRIPTION
In cloud (k8, openshift) i had an issue to deploy the container with plugins.
The entrypoint.sh gave an error trying to copy the plugin file.
