### PR TITLE
Remove redundant command

### DIFF
--- a/4/Dockerfile
+++ b/4/Dockerfile
@@ -10,7 +10,6 @@ STOPSIGNAL SIGINT
 
 RUN	addgroup -S adminer \
 &&	adduser -S -G adminer adminer \
-&&	mkdir -p /var/www/html \
 &&	mkdir -p /var/www/html/plugins-enabled \
 &&	chown -R adminer:adminer /var/www/html
 


### PR DESCRIPTION
`mkdir -p` will create all missing parent directories, so this line is redundant since next line includes the same folder as parent