### PR TITLE
Remove useless `-p` when creating `plugins-enabled/*`

### DIFF
--- a/4/Dockerfile
+++ b/4/Dockerfile
@@ -11,7 +11,7 @@ STOPSIGNAL SIGINT
 RUN	addgroup -S adminer \
 &&	adduser -S -G adminer adminer \
 &&	mkdir -p /var/www/html \
-&&	mkdir -p /var/www/html/plugins-enabled \
+&&	mkdir /var/www/html/plugins-enabled \
 &&	chown -R adminer:adminer /var/www/html
 
 WORKDIR /var/www/html

--- a/4/fastcgi/Dockerfile
+++ b/4/fastcgi/Dockerfile
@@ -9,7 +9,7 @@ RUN	echo "upload_max_filesize = 128M" >> /usr/local/etc/php/conf.d/0-upload_larg
 RUN	addgroup -S adminer \
 &&	adduser -S -G adminer adminer \
 &&	mkdir -p /var/www/html \
-&&	mkdir -p /var/www/html/plugins-enabled \
+&&	mkdir /var/www/html/plugins-enabled \
 &&	chown -R adminer:adminer /var/www/html
 
 RUN	set -x \


### PR DESCRIPTION
Closes #115
