### PR TITLE
add netcat to provide healthcheck

### DIFF
--- a/4/Dockerfile
+++ b/4/Dockerfile
@@ -18,6 +18,7 @@ WORKDIR /var/www/html
 
 RUN	set -x \
 &&	apk add --no-cache --virtual .build-deps \
+	netcat-openbsd \
 	postgresql-dev \
 	sqlite-dev \
 	unixodbc-dev \

--- a/4/fastcgi/Dockerfile
+++ b/4/fastcgi/Dockerfile
@@ -14,6 +14,7 @@ RUN	addgroup -S adminer \
 
 RUN	set -x \
 &&	apk add --no-cache --virtual .build-deps \
+	netcat-openbsd \
 	postgresql-dev \
 	sqlite-dev \
 	unixodbc-dev \


### PR DESCRIPTION
This PR adds netcat to have options to do health check on running container.

Example on terminal
```bash
$ nc -vz 127.0.0.1 8080
```

Example on docker compose based from base into documentation on https://hub.docker.com/_/adminer/:
```yaml
version: '3.1'

services:

  adminer:
    image: adminer
    restart: always
    ports:
      - 8080:8080
    healthcheck:
      test: ["CMD", "nc", "-vz", "127.0.0.1", "8080"]
      interval: 3s
      timeout: 1s
      retries: 20

  db:
    image: mysql:5.6
    restart: always
    environment:
      MYSQL_ROOT_PASSWORD: example
```