### PR TITLE
Fix plug-ins with parameters

### DIFF
--- a/4/entrypoint.sh
+++ b/4/entrypoint.sh
@@ -11,7 +11,9 @@ fi
 
 number=1
 for PLUGIN in $ADMINER_PLUGINS; do
-	php plugin-loader.php "$PLUGIN" > plugins-enabled/$(printf "%03d" $number)-$PLUGIN.php
+	if [ ! -f plugins-enabled/$PLUGIN.php ]; then
+		php plugin-loader.php "$PLUGIN" > plugins-enabled/$(printf "%03d" $number)-$PLUGIN.php
+	fi
 	number=$(($number+1))
 done
 


### PR DESCRIPTION
When I enabled `ADMINER_PLUGINS=login-servers` and created `plugins-enabled/login-servers.php` as instructed in the plugin-loader error message, it would still try to create its own file in plugins-enabled, and then continue to complain, not noticing the file I added.

Let’s skip creating the file when a manually created one exists.