### PR TITLE
AdminerEvo variants

### DIFF
--- a/4/evo-fastcgi/Dockerfile
+++ b/4/evo-fastcgi/Dockerfile
@@ -1,0 +1,58 @@
+FROM php:7.4-fpm-alpine
+
+RUN	echo "upload_max_filesize = 128M" >> /usr/local/etc/php/conf.d/0-upload_large_dumps.ini \
+&&	echo "post_max_size = 128M" >> /usr/local/etc/php/conf.d/0-upload_large_dumps.ini \
+&&	echo "memory_limit = 1G" >> /usr/local/etc/php/conf.d/0-upload_large_dumps.ini \
+&&	echo "max_execution_time = 600" >> /usr/local/etc/php/conf.d/0-upload_large_dumps.ini \
+&&	echo "max_input_vars = 5000" >> /usr/local/etc/php/conf.d/0-upload_large_dumps.ini
+
+RUN	addgroup -S adminer \
+&&	adduser -S -G adminer adminer \
+&&	mkdir -p /var/www/html \
+&&	mkdir /var/www/html/plugins-enabled \
+&&	chown -R adminer:adminer /var/www/html
+
+RUN	set -x \
+&&	apk add --no-cache --virtual .build-deps \
+	postgresql-dev \
+	sqlite-dev \
+	unixodbc-dev \
+	freetds-dev \
+&&	docker-php-ext-configure pdo_odbc --with-pdo-odbc=unixODBC,/usr \
+&&	docker-php-ext-install \
+	mysqli \
+	pdo_pgsql \
+	pdo_sqlite \
+	pdo_odbc \
+	pdo_dblib \
+&&	runDeps="$( \
+		scanelf --needed --nobanner --format '%n#p' --recursive /usr/local/lib/php/extensions \
+			| tr ',' '\n' \
+			| sort -u \
+			| awk 'system("[ -e /usr/local/lib/" $1 " ]") == 0 { next } { print "so:" $1 }' \
+	)" \
+&&	apk add --virtual .phpexts-rundeps $runDeps \
+&&	apk del --no-network .build-deps
+
+COPY	*.php /var/www/html/
+
+ENV	ADMINER_VERSION 4.8.4
+ENV	ADMINER_DOWNLOAD_SHA256 e9a9bc2cc2ac46d6d92f008de9379d2b21a3764a5f8956ed68456e190814b149
+ENV	ADMINER_COMMIT f1e13af9252bfd88d816ef72593513c13adf1dd5
+
+RUN	set -x \
+&&	apk add --no-cache --virtual .build-deps git \
+&&	curl -fsSL "https://github.com/adminerevo/adminerevo/releases/download/v$ADMINER_VERSION/adminer-$ADMINER_VERSION.php" -o adminer.php \
+&&	echo "$ADMINER_DOWNLOAD_SHA256  adminer.php" |sha256sum -c - \
+&&	git clone --recurse-submodules=designs --depth 1 --shallow-submodules --branch "v$ADMINER_VERSION" https://github.com/adminerevo/adminerevo.git /tmp/adminer \
+&&	commit="$(git -C /tmp/adminer/ rev-parse HEAD)" \
+&&	[ "$commit" = "$ADMINER_COMMIT" ] \
+&&	cp -r /tmp/adminer/designs/ /tmp/adminer/plugins/ . \
+&&	rm -rf /tmp/adminer/ \
+&&	apk del --no-network  .build-deps
+
+COPY	entrypoint.sh /usr/local/bin/
+ENTRYPOINT	[ "entrypoint.sh", "docker-php-entrypoint" ]
+
+USER	adminer
+CMD	[ "php-fpm" ]

--- a/4/evo-fastcgi/entrypoint.sh
+++ b/4/evo-fastcgi/entrypoint.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+set -e
+
+if [ -n "$ADMINER_DESIGN" ]; then
+	# Only create link on initial start, to ensure that explicit changes to
+	# adminer.css after the container was started once are preserved.
+	if [ ! -e .adminer-init ]; then
+		ln -sf "designs/$ADMINER_DESIGN/adminer.css" .
+	fi
+fi
+
+number=1
+for PLUGIN in $ADMINER_PLUGINS; do
+	php plugin-loader.php "$PLUGIN" > plugins-enabled/$(printf "%03d" $number)-$PLUGIN.php
+	number=$(($number+1))
+done
+
+touch .adminer-init || true
+
+exec "$@"

--- a/4/evo-fastcgi/index.php
+++ b/4/evo-fastcgi/index.php
@@ -1,0 +1,43 @@
+<?php
+namespace docker {
+	function adminer_object() {
+		require_once('plugins/plugin.php');
+
+		class Adminer extends \AdminerPlugin {
+			function _callParent($function, $args) {
+				if ($function === 'loginForm') {
+					ob_start();
+					$return = \Adminer::loginForm();
+					$form = ob_get_clean();
+
+					echo str_replace('name="auth[server]" value="" title="hostname[:port]"', 'name="auth[server]" value="'.($_ENV['ADMINER_DEFAULT_SERVER'] ?: 'db').'" title="hostname[:port]"', $form);
+
+					return $return;
+				}
+
+				return parent::_callParent($function, $args);
+			}
+		}
+
+		$plugins = [];
+		foreach (glob('plugins-enabled/*.php') as $plugin) {
+			$plugins[] = require($plugin);
+		}
+
+		return new Adminer($plugins);
+	}
+}
+
+namespace {
+	if (basename($_SERVER['DOCUMENT_URI'] ?? $_SERVER['REQUEST_URI']) === 'adminer.css' && is_readable('adminer.css')) {
+		header('Content-Type: text/css');
+		readfile('adminer.css');
+		exit;
+	}
+
+	function adminer_object() {
+		return \docker\adminer_object();
+	}
+
+	require('adminer.php');
+}

--- a/4/evo-fastcgi/plugin-loader.php
+++ b/4/evo-fastcgi/plugin-loader.php
@@ -1,0 +1,73 @@
+<?php
+if (PHP_SAPI !== 'cli') exit;
+if ($_SERVER['argc'] !== 2) exit;
+
+$name = $_SERVER['argv'][1];
+// Sanity checks.
+if (basename($name) !== $name) {
+	fwrite(STDERR, 'Refusing to load plugin file "'.$name.'" for security reasons.'."\n");
+	exit(1);
+}
+if (!is_readable('plugins/'.$name.'.php')) {
+	fwrite(STDERR, 'Unable to find plugin file "'.$name.'".'."\n");
+	exit(1);
+}
+
+// Try to find class.
+$file = 'plugins/'.$name.'.php';
+$code = file_get_contents('plugins/'.$name.'.php');
+$tokens = token_get_all($code);
+
+$classFound = false;
+$classes = [];
+for ($i = 0, $max = count($tokens); $i < $max; $i++) {
+	if ($tokens[$i][0] === T_CLASS) $classFound = true;
+	if ($classFound && $tokens[$i][0] === T_STRING) {
+		$classes[] = $tokens[$i][1];
+		$classFound = false;
+	}
+}
+
+// Sanity checks.
+if (count($classes) == 0) {
+	fwrite(STDERR, 'Unable to load plugin file "'.$name.'", because it does not define any classes.'."\n");
+	exit(1);
+}
+
+if (count($classes) > 1) {
+	fwrite(STDERR, 'Unable to load plugin file "'.$name.'", because it defines multiple classes.'."\n");
+	exit(1);
+}
+
+// Check constructor.
+$class = $classes[0];
+require($file);
+
+$constructor = (new \ReflectionClass($class))->getConstructor();
+
+if ($constructor && $constructor->getNumberOfRequiredParameters() > 0) {
+	$requiredParameters = array_slice($constructor->getParameters(), 0, $constructor->getNumberOfRequiredParameters());
+
+	fwrite(STDERR, 'Unable to load plugin file "'.$name.'", because it has required parameters: '.implode(', ', array_map(function ($item) {
+		return $item->getName();
+	}, $requiredParameters))."\n".
+'Create a file "'.getcwd().'/plugins-enabled/'.$name.'.php" with the following contents to load the plugin:'."\n\n".
+'<?php
+require_once('.var_export($file, true).');
+
+'.$constructor->getDocComment().'
+return new '.$class.'(
+	'.implode(",\n\t", array_map(function ($item) {
+		return '$'.$item->getName()." = ".($item->isOptional() ? var_export($item->getDefaultValue(), true) : '???');
+	}, $constructor->getParameters())).'
+);
+');
+	exit(1);
+}
+
+echo '<?php
+require_once('.var_export($file, true).');
+
+return new '.$class.'();
+';
+exit(0);

--- a/4/evo/Dockerfile
+++ b/4/evo/Dockerfile
@@ -1,0 +1,64 @@
+FROM php:7.4-alpine
+
+RUN	echo "upload_max_filesize = 128M" >> /usr/local/etc/php/conf.d/0-upload_large_dumps.ini \
+&&	echo "post_max_size = 128M" >> /usr/local/etc/php/conf.d/0-upload_large_dumps.ini \
+&&	echo "memory_limit = 1G" >> /usr/local/etc/php/conf.d/0-upload_large_dumps.ini \
+&&	echo "max_execution_time = 600" >> /usr/local/etc/php/conf.d/0-upload_large_dumps.ini \
+&&	echo "max_input_vars = 5000" >> /usr/local/etc/php/conf.d/0-upload_large_dumps.ini
+
+STOPSIGNAL SIGINT
+
+RUN	addgroup -S adminer \
+&&	adduser -S -G adminer adminer \
+&&	mkdir -p /var/www/html \
+&&	mkdir /var/www/html/plugins-enabled \
+&&	chown -R adminer:adminer /var/www/html
+
+WORKDIR /var/www/html
+
+RUN	set -x \
+&&	apk add --no-cache --virtual .build-deps \
+	postgresql-dev \
+	sqlite-dev \
+	unixodbc-dev \
+	freetds-dev \
+&&	docker-php-ext-configure pdo_odbc --with-pdo-odbc=unixODBC,/usr \
+&&	docker-php-ext-install \
+	mysqli \
+	pdo_pgsql \
+	pdo_sqlite \
+	pdo_odbc \
+	pdo_dblib \
+&&	runDeps="$( \
+		scanelf --needed --nobanner --format '%n#p' --recursive /usr/local/lib/php/extensions \
+			| tr ',' '\n' \
+			| sort -u \
+			| awk 'system("[ -e /usr/local/lib/" $1 " ]") == 0 { next } { print "so:" $1 }' \
+	)" \
+&&	apk add --virtual .phpexts-rundeps $runDeps \
+&&	apk del --no-network .build-deps
+
+COPY	*.php /var/www/html/
+
+ENV	ADMINER_VERSION 4.8.4
+ENV	ADMINER_DOWNLOAD_SHA256 e9a9bc2cc2ac46d6d92f008de9379d2b21a3764a5f8956ed68456e190814b149
+ENV	ADMINER_COMMIT f1e13af9252bfd88d816ef72593513c13adf1dd5
+
+RUN	set -x \
+&&	apk add --no-cache --virtual .build-deps git \
+&&	curl -fsSL "https://github.com/adminerevo/adminerevo/releases/download/v$ADMINER_VERSION/adminer-$ADMINER_VERSION.php" -o adminer.php \
+&&	echo "$ADMINER_DOWNLOAD_SHA256  adminer.php" |sha256sum -c - \
+&&	git clone --recurse-submodules=designs --depth 1 --shallow-submodules --branch "v$ADMINER_VERSION" https://github.com/adminerevo/adminerevo.git /tmp/adminer \
+&&	commit="$(git -C /tmp/adminer/ rev-parse HEAD)" \
+&&	[ "$commit" = "$ADMINER_COMMIT" ] \
+&&	cp -r /tmp/adminer/designs/ /tmp/adminer/plugins/ . \
+&&	rm -rf /tmp/adminer/ \
+&&	apk del --no-network  .build-deps
+
+COPY	entrypoint.sh /usr/local/bin/
+ENTRYPOINT	[ "entrypoint.sh", "docker-php-entrypoint" ]
+
+USER	adminer
+CMD	[ "php", "-S", "[::]:8080", "-t", "/var/www/html" ]
+
+EXPOSE 8080

--- a/4/evo/entrypoint.sh
+++ b/4/evo/entrypoint.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+set -e
+
+if [ -n "$ADMINER_DESIGN" ]; then
+	# Only create link on initial start, to ensure that explicit changes to
+	# adminer.css after the container was started once are preserved.
+	if [ ! -e .adminer-init ]; then
+		ln -sf "designs/$ADMINER_DESIGN/adminer.css" .
+	fi
+fi
+
+number=1
+for PLUGIN in $ADMINER_PLUGINS; do
+	php plugin-loader.php "$PLUGIN" > plugins-enabled/$(printf "%03d" $number)-$PLUGIN.php
+	number=$(($number+1))
+done
+
+touch .adminer-init || true
+
+exec "$@"

--- a/4/evo/index.php
+++ b/4/evo/index.php
@@ -1,0 +1,43 @@
+<?php
+namespace docker {
+	function adminer_object() {
+		require_once('plugins/plugin.php');
+
+		class Adminer extends \AdminerPlugin {
+			function _callParent($function, $args) {
+				if ($function === 'loginForm') {
+					ob_start();
+					$return = \Adminer::loginForm();
+					$form = ob_get_clean();
+
+					echo str_replace('name="auth[server]" value="" title="hostname[:port]"', 'name="auth[server]" value="'.($_ENV['ADMINER_DEFAULT_SERVER'] ?: 'db').'" title="hostname[:port]"', $form);
+
+					return $return;
+				}
+
+				return parent::_callParent($function, $args);
+			}
+		}
+
+		$plugins = [];
+		foreach (glob('plugins-enabled/*.php') as $plugin) {
+			$plugins[] = require($plugin);
+		}
+
+		return new Adminer($plugins);
+	}
+}
+
+namespace {
+	if (basename($_SERVER['DOCUMENT_URI'] ?? $_SERVER['REQUEST_URI']) === 'adminer.css' && is_readable('adminer.css')) {
+		header('Content-Type: text/css');
+		readfile('adminer.css');
+		exit;
+	}
+
+	function adminer_object() {
+		return \docker\adminer_object();
+	}
+
+	require('adminer.php');
+}

--- a/4/evo/plugin-loader.php
+++ b/4/evo/plugin-loader.php
@@ -1,0 +1,73 @@
+<?php
+if (PHP_SAPI !== 'cli') exit;
+if ($_SERVER['argc'] !== 2) exit;
+
+$name = $_SERVER['argv'][1];
+// Sanity checks.
+if (basename($name) !== $name) {
+	fwrite(STDERR, 'Refusing to load plugin file "'.$name.'" for security reasons.'."\n");
+	exit(1);
+}
+if (!is_readable('plugins/'.$name.'.php')) {
+	fwrite(STDERR, 'Unable to find plugin file "'.$name.'".'."\n");
+	exit(1);
+}
+
+// Try to find class.
+$file = 'plugins/'.$name.'.php';
+$code = file_get_contents('plugins/'.$name.'.php');
+$tokens = token_get_all($code);
+
+$classFound = false;
+$classes = [];
+for ($i = 0, $max = count($tokens); $i < $max; $i++) {
+	if ($tokens[$i][0] === T_CLASS) $classFound = true;
+	if ($classFound && $tokens[$i][0] === T_STRING) {
+		$classes[] = $tokens[$i][1];
+		$classFound = false;
+	}
+}
+
+// Sanity checks.
+if (count($classes) == 0) {
+	fwrite(STDERR, 'Unable to load plugin file "'.$name.'", because it does not define any classes.'."\n");
+	exit(1);
+}
+
+if (count($classes) > 1) {
+	fwrite(STDERR, 'Unable to load plugin file "'.$name.'", because it defines multiple classes.'."\n");
+	exit(1);
+}
+
+// Check constructor.
+$class = $classes[0];
+require($file);
+
+$constructor = (new \ReflectionClass($class))->getConstructor();
+
+if ($constructor && $constructor->getNumberOfRequiredParameters() > 0) {
+	$requiredParameters = array_slice($constructor->getParameters(), 0, $constructor->getNumberOfRequiredParameters());
+
+	fwrite(STDERR, 'Unable to load plugin file "'.$name.'", because it has required parameters: '.implode(', ', array_map(function ($item) {
+		return $item->getName();
+	}, $requiredParameters))."\n".
+'Create a file "'.getcwd().'/plugins-enabled/'.$name.'.php" with the following contents to load the plugin:'."\n\n".
+'<?php
+require_once('.var_export($file, true).');
+
+'.$constructor->getDocComment().'
+return new '.$class.'(
+	'.implode(",\n\t", array_map(function ($item) {
+		return '$'.$item->getName()." = ".($item->isOptional() ? var_export($item->getDefaultValue(), true) : '???');
+	}, $constructor->getParameters())).'
+);
+');
+	exit(1);
+}
+
+echo '<?php
+require_once('.var_export($file, true).');
+
+return new '.$class.'();
+';
+exit(0);

--- a/generate-stackbrew-library.sh
+++ b/generate-stackbrew-library.sh
@@ -79,7 +79,9 @@ for version in "${versions[@]}"; do
 
 	for variant in \
 		'' \
-		fastcgi \
+		'evo' \
+		'evo-fastcgi' \
+		'fastcgi' \
 	; do
 		dir="$version${variant:+/$variant}"
 		[ -f "$dir/Dockerfile" ] || continue

--- a/update.sh
+++ b/update.sh
@@ -3,6 +3,8 @@ set -Eeuo pipefail
 
 cd "$(dirname "$(readlink -f "$BASH_SOURCE")")"
 
+# update Adminer
+
 versions=( "$@" )
 if [ ${#versions[@]} -eq 0 ]; then
 	versions=( */ )
@@ -21,7 +23,7 @@ for version in "${versions[@]}"; do
 		echo >&2 "error: cannot determine full version for '$version'"
 	fi
 
-	echo "$version: $fullVersion"
+	echo "Adminer $version: $fullVersion"
 
 	downloadSha256="$(
 		curl -fsSL "https://github.com/vrana/adminer/releases/download/v${fullVersion}/adminer-${fullVersion}.php" \
@@ -36,4 +38,41 @@ for version in "${versions[@]}"; do
 		-e 's/^(ENV\s+ADMINER_COMMIT\s+).*/\1'"$commit_hash"'/' \
 		"$version/fastcgi/Dockerfile" \
 		"$version/Dockerfile"
+done
+
+# update AdminerEvo
+
+versions=( "$@" )
+if [ ${#versions[@]} -eq 0 ]; then
+	versions=( */ )
+fi
+versions=( "${versions[@]%/}" )
+
+read -r commit_hash fullVersion << EOF
+$(git ls-remote --tags https://github.com/adminerevo/adminerevo.git \
+	| awk '{gsub(/refs\/tags\/v/, "", $2); print}' \
+	| sort -rVk2 \
+	| head -1)
+EOF
+
+for version in "${versions[@]}"; do
+	if [[ "$fullVersion" != $version* ]]; then
+		echo >&2 "error: cannot determine full version for '$version'"
+	fi
+
+	echo "AdminerEvo $version: $fullVersion"
+
+	downloadSha256="$(
+		curl -fsSL "https://github.com/adminerevo/adminerevo/releases/download/v${fullVersion}/adminer-${fullVersion}.php" \
+			| sha256sum \
+			| cut -d' ' -f1
+	)"
+	echo "  - adminer-${fullVersion}.php: $downloadSha256"
+
+	sed -ri \
+		-e 's/^(ENV\s+ADMINER_VERSION\s+).*/\1'"$fullVersion"'/' \
+		-e 's/^(ENV\s+ADMINER_DOWNLOAD_SHA256\s+).*/\1'"$downloadSha256"'/' \
+		-e 's/^(ENV\s+ADMINER_COMMIT\s+).*/\1'"$commit_hash"'/' \
+		"$version/evo-fastcgi/Dockerfile" \
+		"$version/evo/Dockerfile"
 done


### PR DESCRIPTION
This PR adds two variants for (AdminerEvo](https://github.com/adminerevo/adminerevo) to mitigate the issues due to the depreciation of the original Adminer. They are named as follows:

* evo
* evo-fastcgi

Apart from the repo URL and the release version only the SSH256 hash and commit ID have been changed in the Dockerfiles.

The helper scripts have been updated as well. I've tested them, but since I don't have any experience with maintaining Docker images, these should be checked by a more experienced person.

