### PR TITLE
Revert "Merge branch 'design-submodule'"

### DIFF
--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -71,18 +71,6 @@ jobs:
           |grep 'Nette'
       env:
         container_name: adminer_design
-    - name: Verify that the design works (Submodule).
-      if: ${{ ! contains(steps.build.outputs.image, 'fastcgi') }}
-      run: |
-        docker run --name $container_name -d -e ADMINER_DESIGN=hydra ${{ steps.build.outputs.image }}
-        docker run -i --rm --link $container_name:$container_name buildpack-deps:curl \
-          curl -fsSL http://$container_name:8080/ \
-          |grep 'adminer.css'
-        docker run -i --rm --link $container_name:$container_name buildpack-deps:curl \
-          curl -fsSL http://$container_name:8080/adminer.css \
-          |grep 'Hydra-Dark-Theme-for-Adminer'
-      env:
-        container_name: adminer_design2
     - name: Verify that the default server works.
       if: ${{ ! contains(steps.build.outputs.image, 'fastcgi') }}
       run: |

--- a/4/Dockerfile
+++ b/4/Dockerfile
@@ -42,18 +42,15 @@ COPY	*.php /var/www/html/
 
 ENV	ADMINER_VERSION=4.8.1
 ENV	ADMINER_DOWNLOAD_SHA256=2fd7e6d8f987b243ab1839249551f62adce19704c47d3d0c8dd9e57ea5b9c6b3
-ENV	ADMINER_COMMIT=1f173e18bdf0be29182e0d67989df56eadea4754
+ENV	ADMINER_SRC_DOWNLOAD_SHA256=ef832414296d11eed33e9d85fff3fb316c63f13f05fceb4a961cbe4cb2ae8712
 
 RUN	set -x \
-&&	apk add --no-cache --virtual .build-deps git \
-&&	curl -fsSL "https://github.com/vrana/adminer/releases/download/v$ADMINER_VERSION/adminer-$ADMINER_VERSION.php" -o adminer.php \
+&&	curl -fsSL https://github.com/vrana/adminer/releases/download/v$ADMINER_VERSION/adminer-$ADMINER_VERSION.php -o adminer.php \
 &&	echo "$ADMINER_DOWNLOAD_SHA256  adminer.php" |sha256sum -c - \
-&&	git clone --recurse-submodules=designs --depth 1 --shallow-submodules --branch "v$ADMINER_VERSION" https://github.com/vrana/adminer.git /tmp/adminer \
-&&	commit="$(git -C /tmp/adminer/ rev-parse HEAD)" \
-&&	[ "$commit" = "$ADMINER_COMMIT" ] \
-&&	cp -r /tmp/adminer/designs/ /tmp/adminer/plugins/ . \
-&&	rm -rf /tmp/adminer/ \
-&&	apk del --no-network  .build-deps
+&&	curl -fsSL https://github.com/vrana/adminer/archive/v$ADMINER_VERSION.tar.gz -o source.tar.gz \
+&&	echo "$ADMINER_SRC_DOWNLOAD_SHA256  source.tar.gz" |sha256sum -c - \
+&&	tar xzf source.tar.gz --strip-components=1 "adminer-$ADMINER_VERSION/designs/" "adminer-$ADMINER_VERSION/plugins/" \
+&&	rm source.tar.gz
 
 COPY	entrypoint.sh /usr/local/bin/
 ENTRYPOINT	[ "entrypoint.sh", "docker-php-entrypoint" ]

--- a/4/fastcgi/Dockerfile
+++ b/4/fastcgi/Dockerfile
@@ -38,18 +38,15 @@ COPY	*.php /var/www/html/
 
 ENV	ADMINER_VERSION=4.8.1
 ENV	ADMINER_DOWNLOAD_SHA256=2fd7e6d8f987b243ab1839249551f62adce19704c47d3d0c8dd9e57ea5b9c6b3
-ENV	ADMINER_COMMIT=1f173e18bdf0be29182e0d67989df56eadea4754
+ENV	ADMINER_SRC_DOWNLOAD_SHA256=ef832414296d11eed33e9d85fff3fb316c63f13f05fceb4a961cbe4cb2ae8712
 
 RUN	set -x \
-&&	apk add --no-cache --virtual .build-deps git \
-&&	curl -fsSL "https://github.com/vrana/adminer/releases/download/v$ADMINER_VERSION/adminer-$ADMINER_VERSION.php" -o adminer.php \
+&&	curl -fsSL https://github.com/vrana/adminer/releases/download/v$ADMINER_VERSION/adminer-$ADMINER_VERSION.php -o adminer.php \
 &&	echo "$ADMINER_DOWNLOAD_SHA256  adminer.php" |sha256sum -c - \
-&&	git clone --recurse-submodules=designs --depth 1 --shallow-submodules --branch "v$ADMINER_VERSION" https://github.com/vrana/adminer.git /tmp/adminer \
-&&	commit="$(git -C /tmp/adminer/ rev-parse HEAD)" \
-&&	[ "$commit" = "$ADMINER_COMMIT" ] \
-&&	cp -r /tmp/adminer/designs/ /tmp/adminer/plugins/ . \
-&&	rm -rf /tmp/adminer/ \
-&&	apk del --no-network  .build-deps
+&&	curl -fsSL https://github.com/vrana/adminer/archive/v$ADMINER_VERSION.tar.gz -o source.tar.gz \
+&&	echo "$ADMINER_SRC_DOWNLOAD_SHA256  source.tar.gz" |sha256sum -c - \
+&&	tar xzf source.tar.gz --strip-components=1 "adminer-$ADMINER_VERSION/designs/" "adminer-$ADMINER_VERSION/plugins/" \
+&&	rm source.tar.gz
 
 COPY	entrypoint.sh /usr/local/bin/
 ENTRYPOINT	[ "entrypoint.sh", "docker-php-entrypoint" ]

--- a/update.sh
+++ b/update.sh
@@ -9,15 +9,20 @@ if [ ${#versions[@]} -eq 0 ]; then
 fi
 versions=( "${versions[@]%/}" )
 
-read -r commit_hash fullVersion << EOF
-$(git ls-remote --tags https://github.com/vrana/adminer.git \
-	| awk '{gsub(/refs\/tags\/v/, "", $2); print}' \
-	| sort -rVk2 \
-	| head -1)
-EOF
+allVersions="$(
+	git ls-remote --tags https://github.com/vrana/adminer.git \
+		| cut -d$'\t' -f2 \
+		| grep -E '^refs/tags/v[0-9]+\.[0-9]+' \
+		| cut -dv -f2 \
+		| sort -rV
+)"
 
 for version in "${versions[@]}"; do
-	if [[ "$fullVersion" != $version* ]]; then
+	fullVersion="$(
+		grep -E "^${version}([.-]|$)" <<<"$allVersions" \
+			| head -1
+	)"
+	if [ -z "$fullVersion" ]; then
 		echo >&2 "error: cannot determine full version for '$version'"
 	fi
 
@@ -30,10 +35,17 @@ for version in "${versions[@]}"; do
 	)"
 	echo "  - adminer-${fullVersion}.php: $downloadSha256"
 
+	srcDownloadSha256="$(
+		curl -fsSL "https://github.com/vrana/adminer/archive/v${fullVersion}.tar.gz" \
+			| sha256sum \
+			| cut -d' ' -f1
+	)"
+	echo "  - v${fullVersion}.tar.gz: $srcDownloadSha256"
+
 	sed -ri \
 		-e 's/^(ENV\s+ADMINER_VERSION=).*/\1'"$fullVersion"'/' \
 		-e 's/^(ENV\s+ADMINER_DOWNLOAD_SHA256=).*/\1'"$downloadSha256"'/' \
-		-e 's/^(ENV\s+ADMINER_COMMIT=).*/\1'"$commit_hash"'/' \
+		-e 's/^(ENV\s+ADMINER_SRC_DOWNLOAD_SHA256=).*/\1'"$srcDownloadSha256"'/' \
 		"$version/fastcgi/Dockerfile" \
 		"$version/Dockerfile"
 done


### PR DESCRIPTION
Since Adminer 4.16.0, the design submodules have been removed.

This reverts commit a33715da87da561aff6780fb6f6813d3a6bada95, reversing changes made to 951b69c04de4d5c123abf89a2c8652ee681579be.