### PR TITLE
`apk add` with `--no-cache`

### DIFF
--- a/5/Dockerfile
+++ b/5/Dockerfile
@@ -35,7 +35,7 @@ RUN	set -x \
 			| sort -u \
 			| awk 'system("[ -e /usr/local/lib/" $1 " ]") == 0 { next } { print "so:" $1 }' \
 	)" \
-&&	apk add --virtual .phpexts-rundeps $runDeps \
+&&	apk add --no-cache --virtual .phpexts-rundeps $runDeps \
 &&	apk del --no-network .build-deps
 
 COPY	*.php /var/www/html/

--- a/5/fastcgi/Dockerfile
+++ b/5/fastcgi/Dockerfile
@@ -31,7 +31,7 @@ RUN	set -x \
 			| sort -u \
 			| awk 'system("[ -e /usr/local/lib/" $1 " ]") == 0 { next } { print "so:" $1 }' \
 	)" \
-&&	apk add --virtual .phpexts-rundeps $runDeps \
+&&	apk add --no-cache --virtual .phpexts-rundeps $runDeps \
 &&	apk del --no-network .build-deps
 
 COPY	*.php /var/www/html/


### PR DESCRIPTION
Use `--no-cache` option on `apk add` to reduce docker image layer size